### PR TITLE
Enable Docker on Boot for CentOS/ RHEL 7

### DIFF
--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -116,12 +116,8 @@ fi
 
 # Start the Docker service:
 echo "Starting the docker service..."
-if [ -s /etc/lsb-release ] && grep -iq '^DISTRIB_ID *= *Ubuntu' /etc/lsb-release ; then
-	$SUDO systemctl start docker
-	$SUDO systemctl enable docker
-elif [ -s /etc/redhat-release ] && grep -iq 'release 7' /etc/redhat-release  ; then
-	$SUDO service docker start
-fi
+$SUDO systemctl start docker
+$SUDO systemctl enable docker
 echo "Docker service started."
 
 ./check_docker-compose.sh


### PR DESCRIPTION
The install docker script does not set docker to start at boot on CentOS/ RHEL systems. This PR fixes that so docker starts at boot for both Ubuntu and RHEL systems.