### PR TITLE
Overwrite docker compose if an unsupported version exists on the machine

### DIFF
--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -126,7 +126,8 @@ DOCKER_COMPOSE_CHECK=$?
 if [ "$DOCKER_COMPOSE_CHECK" -gt 3 ]; then
 	# This may overwrite a file maintained by a package.
 	echo "An unsupported version of Docker-Compose appears to already be installed. It will be replaced."
-elif [ "$DOCKER_COMPOSE_CHECK" -eq 0 ]; then
+fi
+if [ "$DOCKER_COMPOSE_CHECK" -eq 0 ]; then
 	echo "Docker-Compose appears to already be installed. Skipping."
 else
 	### Install Docker-Compose ###


### PR DESCRIPTION
It looks like two separate if/fi blocks were accidentally merged. This prevented installing docker-compose when an existing, unsupported version existed. Github actions's ubuntu image contains docker-compose 1.26 and was causing issues with the installer.