### PR TITLE
Disable max docker version check

### DIFF
--- a/docker/check_docker.sh
+++ b/docker/check_docker.sh
@@ -22,6 +22,7 @@ VERSION_MINOR="$(echo $VERSION | cut -d' ' -f2)"
 if [ "$VERSION_MAJOR" -lt "$MIN_VERSION_MAJOR" ] ||
 	[ "$VERSION_MAJOR" -eq "$MIN_VERSION_MAJOR" -a "$VERSION_MINOR" -lt "$MIN_VERSION_MINOR" ]; then
 	exit 4
+# Disabled in https://github.com/activecm/shell-lib/pull/9
 # elif [ "$VERSION_MAJOR" -gt "$MAX_VERSION_MAJOR" ] ||
 # 	[ "$VERSION_MAJOR" -eq "$MAX_VERSION_MAJOR" -a "$VERSION_MINOR" -gt "$MAX_VERSION_MINOR" ]; then
 # 	exit 5

--- a/docker/check_docker.sh
+++ b/docker/check_docker.sh
@@ -22,9 +22,9 @@ VERSION_MINOR="$(echo $VERSION | cut -d' ' -f2)"
 if [ "$VERSION_MAJOR" -lt "$MIN_VERSION_MAJOR" ] ||
 	[ "$VERSION_MAJOR" -eq "$MIN_VERSION_MAJOR" -a "$VERSION_MINOR" -lt "$MIN_VERSION_MINOR" ]; then
 	exit 4
-elif [ "$VERSION_MAJOR" -gt "$MAX_VERSION_MAJOR" ] ||
-	[ "$VERSION_MAJOR" -eq "$MAX_VERSION_MAJOR" -a "$VERSION_MINOR" -gt "$MAX_VERSION_MINOR" ]; then
-	exit 5
+# elif [ "$VERSION_MAJOR" -gt "$MAX_VERSION_MAJOR" ] ||
+# 	[ "$VERSION_MAJOR" -eq "$MAX_VERSION_MAJOR" -a "$VERSION_MINOR" -gt "$MAX_VERSION_MINOR" ]; then
+# 	exit 5
 else
 	exit 0
 fi


### PR DESCRIPTION
Checking for a max version of docker doesn't do us much good
1) We don't pin the version of docker which means that an update to docker tomorrow could cause this to trip in an installer generated today.
2) Docker doesn't have a track record of breaking backwards compatibility. I think the minimum version check is more important since we know which features and the version they were introduced.

I left the docker-compose check in for the opposite reasons:
1) Our install does pin a specific docker-compose version and it doesn't get auto-updated by the package manager.
2) Newer versions of docker-compose have caused an issue with some of our scripts before.
3) Since docker-compose is a wrapper around docker and doesn't really add any additional functionality (only convenience) then I don't see updates for security being as likely for docker-compose as they are for docker. Thus it's not as important to keep docker-compose up to date.