### PR TITLE
Fix issue where rust setup tools wasn't included with pip by default

### DIFF
--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -152,6 +152,7 @@ else
 	#else
 
 	#github doesn't have aarch64 binary releases for docker-compose, install via pip3 instead (on every architecture, to simplify this script)
+	$SUDO pip3 install --upgrade pip
 	$SUDO pip3 install docker-compose==${DOCKER_COMPOSE_VERSION}
 
 	#fi


### PR DESCRIPTION
Fix installing docker-compose when the packaged version of pip does not include rust setup tools.

Example error log:
![image](https://user-images.githubusercontent.com/761220/160009777-81669a88-7ce7-4355-af74-947012dd371a.png)
