### PR TITLE
Support installing and running docker-compose under sudo on Ubuntu 16 and CentOS 7

### DIFF
--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -169,6 +169,12 @@ sys.exit(1)
 	else 
 		fail 'docker-compose could not be automatically installed on this system. Please install it manually and re-run the script.'
 	fi
+
+	# Some OS don't insert /usr/local/bin into the PATH when running SUDO (CentOS)
+	# Provide a symlink in /usr/bin in order to get around this issue.
+	if [ ! -e /usr/bin/docker-compose ]; then 
+    	$SUDO ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
+	fi
 fi
 
 if [ "${ADD_DOCKER_GROUP}" = "true" ]; then

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -146,16 +146,29 @@ else
 	DOCKER_COMPOSE_VERSION="1.25.5"
 
 	echo "Installing Docker-Compose v${DOCKER_COMPOSE_VERSION}..."
-	#if [ "$(uname -m)" = "x86_64" ]; then
-	#	$SUDO_E curl --silent -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` -o /usr/bin/docker-compose
-	#	$SUDO chmod +x /usr/bin/docker-compose
-	#else
 
-	#github doesn't have aarch64 binary releases for docker-compose, install via pip3 instead (on every architecture, to simplify this script)
-	$SUDO pip3 install --upgrade pip
-	$SUDO pip3 install docker-compose==${DOCKER_COMPOSE_VERSION}
-
-	#fi
+	# Check if the latest version of pip is supported by the version of python installed
+	# In particular, Ubuntu 16's version of python (v3.5) does not support the latest verison of pip
+	MIN_PYTHON_VERSION_MAJOR=3
+	MIN_PYTHON_VERSION_MINOR=6
+	PYTHON_VERSION_TEST="
+import sys
+if  (sys.version_info.major > $MIN_PYTHON_VERSION_MAJOR or 
+	(sys.version_info.major == $MIN_PYTHON_VERSION_MAJOR and sys.version_info.minor >= $MIN_PYTHON_VERSION_MINOR)): 
+	sys.exit(0)
+sys.exit(1)
+"
+	if python3 -c "$PYTHON_VERSION_TEST"; then 
+		# prefer to install with pip3 if possible since github doesn't have aarch64 binary releases for docker-compose
+		$SUDO pip3 install --upgrade pip
+		$SUDO pip3 install docker-compose==${DOCKER_COMPOSE_VERSION}
+	elif [ "$(uname -m)" = "x86_64" ]; then
+		# if we are on x86, download docker-compose from Github
+		$SUDO_E curl --silent -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose
+		$SUDO chmod +x /usr/local/bin/docker-compose
+	else 
+		fail 'docker-compose could not be automatically installed on this system. Please install it manually and re-run the script.'
+	fi
 fi
 
 if [ "${ADD_DOCKER_GROUP}" = "true" ]; then

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -160,8 +160,14 @@ sys.exit(1)
 "
 	if python3 -c "$PYTHON_VERSION_TEST"; then 
 		# prefer to install with pip3 if possible since github doesn't have aarch64 binary releases for docker-compose
-		$SUDO pip3 install --upgrade pip
-		$SUDO pip3 install docker-compose==${DOCKER_COMPOSE_VERSION}
+
+		# pip3 recommends -H when running with sudo to prevent creating root owned files in the user's home dir
+		PIP3_CMD="pip3"
+		if [ -n "$SUDO" ]; then
+			PIP3_CMD="$SUDO -H $PIP3_CMD"
+		fi
+		$PIP3_CMD install --upgrade pip
+		$PIP3_CMD install docker-compose==${DOCKER_COMPOSE_VERSION}
 	elif [ "$(uname -m)" = "x86_64" ]; then
 		# if we are on x86, download docker-compose from Github
 		$SUDO_E curl --silent -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -167,7 +167,7 @@ sys.exit(1)
 			PIP3_CMD="$SUDO -H $PIP3_CMD"
 		fi
 		$PIP3_CMD install --upgrade pip
-		$PIP3_CMD install docker-compose==${DOCKER_COMPOSE_VERSION}
+		$PIP3_CMD install --no-warn-script-location docker-compose==${DOCKER_COMPOSE_VERSION}
 	elif [ "$(uname -m)" = "x86_64" ]; then
 		# if we are on x86, download docker-compose from Github
 		$SUDO_E curl --silent -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` -o /usr/local/bin/docker-compose

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -162,7 +162,7 @@ sys.exit(1)
 		# prefer to install with pip3 if possible since github doesn't have aarch64 binary releases for docker-compose
 
 		# pip3 recommends -H when running with sudo to prevent creating root owned files in the user's home dir
-		PIP3_CMD="pip3"
+		PIP3_CMD="python3 -m pip"
 		if [ -n "$SUDO" ]; then
 			PIP3_CMD="$SUDO -H $PIP3_CMD"
 		fi


### PR DESCRIPTION
#### Changes:
- Check if `python3` version is at least `3.6` before using `pip` to install `docker-compose`
  - This ensures we do not try to use `pip` on systems which don't support the latest version of `pip` (Ubuntu 16)
- Otherwise, if on an x86-64 system, install `docker-compose` from Github
  -  Reuses old commented out code, but installs `docker-compose` to `/usr/local/bin` to match `pip`
- Adds the `-H` flag to sudo to ensure that `pip` caches files in `/root` rather than in the current user's home directory
- Adds a symlink from `/usr/bin/docker-compose` to `/usr/local/bin/docker-compose`
  - This solves an issue where running `sudo docker-compose` on CentOS 7 failed since `/usr/local/bin` is not in the `PATH` variable when running a command under `sudo`

Closes #18

#### Testing
I created a local build of AC-Hunter by checking out this branch of shell-lib and successfully installed AC-Hunter on both Ubuntu 16 and CentOS. Additionally, I ran the `ach-status.sh` script without any issues.