### PR TITLE
Remove docker as installed by snap

### DIFF
--- a/docker/check_docker.sh
+++ b/docker/check_docker.sh
@@ -5,6 +5,7 @@
 # 3 not installed
 # 4 older than required minimum version
 # 5 newer than required maximum version
+# 6 Docker is installed via snap, which is incompatible with ActiveCM software
 
 if [ ! -x "$(command -v docker)" ]; then
 	exit 3
@@ -26,6 +27,8 @@ if [ "$VERSION_MAJOR" -lt "$MIN_VERSION_MAJOR" ] ||
 # elif [ "$VERSION_MAJOR" -gt "$MAX_VERSION_MAJOR" ] ||
 # 	[ "$VERSION_MAJOR" -eq "$MAX_VERSION_MAJOR" -a "$VERSION_MINOR" -gt "$MAX_VERSION_MINOR" ]; then
 # 	exit 5
+elif [ "$(command -v docker)" = "/snap/bin/docker" ]; then
+	exit 6
 else
 	exit 0
 fi

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -58,6 +58,10 @@ if [ "$DOCKER_CHECK" -gt 3 ]; then
 	# This may overwrite a file maintained by a package.
 	echo "An unsupported version of Docker appears to already be installed. It will be replaced."
 fi
+if [ "$DOCKER_CHECK" -eq 6 ]; then 
+	echo "Docker is installed via snap, which is incompatible with ActiveCM software. Removing Docker via snap."
+	$SUDO snap remove docker
+fi
 if [ "$DOCKER_CHECK" -eq 0 ]; then
 	echo "Docker appears to already be installed. Skipping."
 elif [ -s /etc/redhat-release ] && grep -iq 'release 7' /etc/redhat-release ; then


### PR DESCRIPTION
Our docker-zeek package is incompatible with Docker when Docker is installed with `snap`. This PR ensures that Docker is installed with `apt` or `yum`.