### PR TITLE
Add tzdata to list of required utilities

### DIFF
--- a/acmlib.sh
+++ b/acmlib.sh
@@ -393,7 +393,7 @@ ensure_common_tools_installed () {
 
     local ubuntu_tools="gdb wget curl make netcat lsb-release rsync unzip tar"
     local centos_tools="gdb wget curl make nmap-ncat coreutils iproute redhat-lsb-core rsync unzip tar"
-    local required_tools="adduser awk cat chmod chown cp curl date egrep gdb getent grep ip lsb_release make mkdir mv nc passwd printf rm rsync sed ssh-keygen sleep tar tee tr unzip wc wget"
+    local required_tools="adduser awk cat chmod chown cp curl date egrep gdb getent grep ip lsb_release make mkdir mv nc passwd printf rm rsync sed ssh-keygen sleep tar tee tr tzdata unzip wc wget"
     if [ -x /usr/bin/apt-get -a -x /usr/bin/dpkg-query ]; then
         #We have apt-get, good.
 


### PR DESCRIPTION
The Docker containers which depend on shell-lib require bind mounting `/etc/localtime` in order to generate valid timestamps. Stripped down operating systems may not provide a copy of `/etc/localtime` by default. This PR adds the `tzdata` package to the list of shell-lib's required utilities in order to ensure this file exists.

See https://github.com/dotnet/dotnet-docker/issues/1264 for an example of others running into this issue.

In order to test this, I have verified that `yum install tzdata` on CentOS 7.9, and `apt install tzdata` on Ubuntu 18/ 20 ran successfully. 