### PR TITLE
Ensure tzdata, iproute, and openssh-client are installed

### DIFF
--- a/acmlib.sh
+++ b/acmlib.sh
@@ -385,6 +385,26 @@ can_write_or_create () {
     fi
 }
 
+install_tzdata() {
+	# attempt to install tzdata on ubuntu as it can be missing on some barebone installs
+	if [ -x /usr/bin/apt-get -a -x /usr/bin/dpkg-query ]; then
+		# set env variables to install tzdata without a prompt
+		export DEBIAN_FRONTEND=noninteractive
+		# set timezone to UTC
+		export TZ=Etc/UTC
+		if [ ! -f /etc/localtime ]; then
+			$SUDO apt-get -q -y install tzdata
+		fi
+		# check if tzdata successfully installed
+		if [ ! -f /etc/localtime ]; then
+			echo "WARNING: Unable to install tzdata" >&2
+			return 1
+		fi
+		export DEBIAN_FRONTEND=""
+		export TZ=""
+	fi
+}
+
 ensure_common_tools_installed () {
     #Installs common tools used by acm scripts. Supports yum and apt-get.
     #Stops the script if neither apt-get nor yum exist.
@@ -393,7 +413,8 @@ ensure_common_tools_installed () {
 
     local ubuntu_tools="gdb wget curl make netcat lsb-release rsync unzip tar"
     local centos_tools="gdb wget curl make nmap-ncat coreutils iproute redhat-lsb-core rsync unzip tar"
-    local required_tools="adduser awk cat chmod chown cp curl date egrep gdb getent grep ip lsb_release make mkdir mv nc passwd printf rm rsync sed ssh-keygen sleep tar tee tr tzdata unzip wc wget"
+    local required_tools="adduser awk cat chmod chown cp curl date egrep gdb getent grep ip lsb_release make mkdir mv nc passwd printf rm rsync sed ssh-keygen sleep tar tee tr unzip wc wget"
+    install_tzdata
     if [ -x /usr/bin/apt-get -a -x /usr/bin/dpkg-query ]; then
         #We have apt-get, good.
 

--- a/acmlib.sh
+++ b/acmlib.sh
@@ -415,9 +415,10 @@ ensure_common_tools_installed () {
                 fi
             fi
         fi
-
+        
         # set env variables to install without prompts (e.g. tzdata)
-        export DEBIAN_FRONTEND=noninteractive  # this only applies to child processes. There is no need to reset it back to its original state.
+        local old_deb_frontend="$DEBIAN_FRONTEND"
+        export DEBIAN_FRONTEND=noninteractive
 
         #We're returning to showing stderr because using "-qq" and redirecting stderr to /dev/null meant the user could never see why an install was failing.
         while ! $SUDO apt-get -q -y update >/dev/null ; do
@@ -428,6 +429,9 @@ ensure_common_tools_installed () {
             echo2 "Error installing packages, perhaps because a system update is running; will wait 60 seconds and try again."
             sleep 60
         done
+
+        export DEBIAN_FRONTEND="$old_deb_frontend"
+
     elif [ -x /usr/bin/yum -a -x /bin/rpm ]; then
         #We have yum, good.
 


### PR DESCRIPTION
This PR fixes a bug introduced in #24 which caused `ensure_common_tools_installed` to crash since `tzdata` is not an executable binary on the system. 

This PR ensures that tzdata is installed without prompting the user. The `Etc/UTC` timezone is set by default. 

Additionally, while testing `ensure_common_tools_installed`, I found that the required tool `ssh-keygen` was not present in minimal Ubuntu 18 or Centos 7 images. To fix this, I have added `openssh-client` to the list of Ubuntu tools and `openssh-clients` to the list of RHEL tools. 

Similarly, the `ip` command was missing in the Ubuntu 18 base image. I added `iproute2` to the list of Ubuntu tools to solve this issue. 

I tested the `ensure_common_tools_installed` routine in the following Docker images:
- ubuntu:16.04
- ubuntu:18.04
- ubuntu:20.04
- ubuntu:22.04
- centos:7
- quay.io/centos/centos:stream (official rolling release distro that is set to replace fixed releases of CentOS in the future)
- almalinux:8 (fixed release fork of CentOS which has been gaining traction as a replacement for fixed releases of CentOS)

On the post CentOS-7 RHEL based installations there is a package which conflicts with `coreutils` that provides the same executables. I have added `--skip-broken` to prevent the `yum` command from getting stuck when trying to deal with this. This flag simply tells `yum` to skip over any packages which it cannot readily install. I felt comfortable adding this since we check for the installed utilities after running the installations.

I used the following shell commands to test the function in each of these Docker images:
```sh
sudo docker run -it --rm -v `realpath relative/path/to/shell-lib/acmlib.sh`:/root/acmlib.sh ubuntu:18.04 bash 
[sudo] password for logan: 
root@09043a9426cb:/# . /root/acmlib.sh 
root@09043a9426cb:/# ensure_common_tools_installed
```

