### PR TITLE
Fix unattended tzdata install

### DIFF
--- a/acmlib.sh
+++ b/acmlib.sh
@@ -385,6 +385,26 @@ can_write_or_create () {
     fi
 }
 
+install_tzdata() {
+	# attempt to install tzdata on ubuntu as it can be missing on some barebone installs
+	if [ -x /usr/bin/apt-get -a -x /usr/bin/dpkg-query ]; then
+		# set env variables to install tzdata without a prompt
+		export DEBIAN_FRONTEND=noninteractive
+		# set timezone to UTC
+		export TZ=Etc/UTC
+		if [ ! -f /etc/localtime ]; then
+			$SUDO apt-get -q -y install tzdata
+		fi
+		# check if tzdata successfully installed
+		if [ ! -f /etc/localtime ]; then
+			echo "WARNING: Unable to install tzdata" >&2
+			return 1
+		fi
+		export DEBIAN_FRONTEND=""
+		export TZ=""
+	fi
+}
+
 ensure_common_tools_installed () {
     #Installs common tools used by acm scripts. Supports yum and apt-get.
     #Stops the script if neither apt-get nor yum exist.
@@ -393,7 +413,8 @@ ensure_common_tools_installed () {
 
     local ubuntu_tools="gdb wget curl make netcat lsb-release rsync unzip tar"
     local centos_tools="gdb wget curl make nmap-ncat coreutils iproute redhat-lsb-core rsync unzip tar"
-    local required_tools="adduser awk cat chmod chown cp curl date egrep gdb getent grep ip lsb_release make mkdir mv nc passwd printf rm rsync sed ssh-keygen sleep tar tee tr tzdata unzip wc wget"
+    local required_tools="adduser awk cat chmod chown cp curl date egrep gdb getent grep ip lsb_release make mkdir mv nc passwd printf rm rsync sed ssh-keygen sleep tar tee tr unzip wc wget"
+    install_tzdata
     if [ -x /usr/bin/apt-get -a -x /usr/bin/dpkg-query ]; then
         #We have apt-get, good.
 

--- a/acmlib.sh
+++ b/acmlib.sh
@@ -419,18 +419,22 @@ ensure_common_tools_installed () {
         # set env variables to install without prompts (e.g. tzdata)
         local old_deb_frontend="$DEBIAN_FRONTEND"
         export DEBIAN_FRONTEND=noninteractive
+        local old_tz="$TZ"
+        export TZ=Etc/UTC
+        $SUDO ln -fs /usr/share/zoneinfo/UTC /etc/localtime
 
         #We're returning to showing stderr because using "-qq" and redirecting stderr to /dev/null meant the user could never see why an install was failing.
         while ! $SUDO apt-get -q -y update >/dev/null ; do
             echo2 "Error updating package metadata, perhaps because a system update is running; will wait 60 seconds and try again."
             sleep 60
         done
-        while ! $SUDO apt-get -q -y install $ubuntu_tools >/dev/null ; do
+        while ! $SUDO apt-get -q -y install $ubuntu_tools ; do
             echo2 "Error installing packages, perhaps because a system update is running; will wait 60 seconds and try again."
             sleep 60
         done
 
         export DEBIAN_FRONTEND="$old_deb_frontend"
+        export TZ="$old_tz"
 
     elif [ -x /usr/bin/yum -a -x /bin/rpm ]; then
         #We have yum, good.

--- a/acmlib.sh
+++ b/acmlib.sh
@@ -415,9 +415,10 @@ ensure_common_tools_installed () {
                 fi
             fi
         fi
-
+        
         # set env variables to install without prompts (e.g. tzdata)
-        export DEBIAN_FRONTEND=noninteractive  # this only applies to child processes. There is no need to reset it back to its original state.
+        local old_deb_frontend="$DEBIAN_FRONTEND"
+        export DEBIAN_FRONTEND=noninteractive
 
         #We're returning to showing stderr because using "-qq" and redirecting stderr to /dev/null meant the user could never see why an install was failing.
         while ! $SUDO apt-get -q -y update >/dev/null ; do
@@ -428,6 +429,9 @@ ensure_common_tools_installed () {
             echo2 "Error installing packages, perhaps because a system update is running; will wait 60 seconds and try again."
             sleep 60
         done
+
+        export DEBIAN_FRONTEND="$old_deb_frontend"
+
     elif [ -x /usr/bin/yum -a -x /bin/rpm ]; then
         #We have yum, good.
 


### PR DESCRIPTION
The current fix for installing tzdata removed the exporting of `TZ` with the desired UTC timezone. This causes the tzdata installer to prompt for the lookup of the desired timezone.
While testing the install with the `TZ` env variable added back in, the installation would still prompt although it did not prompt during the initial testing on my `install_tzdata` function. 
I added in a symlink that many people use to get tzdata to install without a prompt from `/usr/share/zoneinfo/UTC` to `/etc/localtime`. This got tzdata to install without a prompt. 

Also, piping the install of `$ubuntu_tools` out to `/dev/null` will cause the script to hang if the tzdata prompt does display, giving the user a false sense of hanging up and making it more difficult to test.

I tested this by copying over the modified `acmlib.sh` script over to an Ubuntu 18 system running in Azure and running `ensure_common_tools_installed`