### PR TITLE
Update docker-compose to v1.29.2

### DIFF
--- a/docker/check_docker-compose.sh
+++ b/docker/check_docker-compose.sh
@@ -13,7 +13,7 @@ fi
 MIN_VERSION_MAJOR=1
 MIN_VERSION_MINOR=16
 MAX_VERSION_MAJOR=1
-MAX_VERSION_MINOR=25
+MAX_VERSION_MINOR=29
 
 pushd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null
 source ../acmlib.sh

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -147,7 +147,7 @@ if [ "$DOCKER_COMPOSE_CHECK" -eq 0 ]; then
 else
 	### Install Docker-Compose ###
 	# https://docs.docker.com/compose/install/#install-compose
-	DOCKER_COMPOSE_VERSION="1.25.5"
+	DOCKER_COMPOSE_VERSION="1.29.2"
 
 	echo "Installing Docker-Compose v${DOCKER_COMPOSE_VERSION}..."
 


### PR DESCRIPTION
On certain machines (primarily Ubuntu 20), the python-openssl apt package conflicts with the dependencies of docker-compose leading to the following stack trace when trying to run docker-compose after it has been installed with `pip`.

Upgrading docker-compose to the latest version on the v1 branch fixes this issue. 

To test this PR, run `install_docker.sh` on a fully up to date Ubuntu 20 machine and then run `docker-compose`.

```
Original exception was:
Traceback (most recent call last):
  File "/usr/local/bin/docker-compose", line 5, in <module>
    from compose.cli.main import main
  File "/usr/local/lib/python3.8/dist-packages/compose/cli/main.py", line 18, in <module>
    import docker.errors
  File "/usr/local/lib/python3.8/dist-packages/docker/__init__.py", line 2, in <module>
    from .api import APIClient
  File "/usr/local/lib/python3.8/dist-packages/docker/api/__init__.py", line 2, in <module>
    from .client import APIClient
  File "/usr/local/lib/python3.8/dist-packages/docker/api/client.py", line 5, in <module>
    import requests
  File "/usr/lib/python3/dist-packages/requests/__init__.py", line 95, in <module>
    from urllib3.contrib import pyopenssl
  File "/usr/lib/python3/dist-packages/urllib3/contrib/pyopenssl.py", line 46, in <module>
    import OpenSSL.SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/__init__.py", line 8, in <module>
    from OpenSSL import crypto, SSL
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1553, in <module>
    class X509StoreFlags(object):
  File "/usr/lib/python3/dist-packages/OpenSSL/crypto.py", line 1573, in X509StoreFlags
    CB_ISSUER_CHECK = _lib.X509_V_FLAG_CB_ISSUER_CHECK
AttributeError: module 'lib' has no attribute 'X509_V_FLAG_CB_ISSUER_CHECK'
```