### PR TITLE
Centos 8 installation fixes

### DIFF
--- a/acmlib.sh
+++ b/acmlib.sh
@@ -291,7 +291,7 @@ warn_docker_network_in_use() {
 }
 
 check_os_is_centos () {
-    [ -s /etc/redhat-release ] && grep -iq 'release 7' /etc/redhat-release
+    [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8' /etc/redhat-release
 }
 
 check_os_is_ubuntu () {

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -64,7 +64,7 @@ if [ "$DOCKER_CHECK" -eq 6 ]; then
 fi
 if [ "$DOCKER_CHECK" -eq 0 ]; then
 	echo "Docker appears to already be installed. Skipping."
-elif [ -s /etc/redhat-release ] && grep -iq 'release 7' /etc/redhat-release ; then
+elif [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8' /etc/redhat-release ; then
 	#This configuration file is used in both Redhat RHEL and Centos distributions, so we're running under RHEL/Centos 7.x
 	# https://docs.docker.com/engine/installation/linux/docker-ce/centos/
 

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -68,6 +68,16 @@ elif [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8' /etc/redhat-r
 	#This configuration file is used in both Redhat RHEL and Centos distributions, so we're running under RHEL/Centos 7.x
 	# https://docs.docker.com/engine/installation/linux/docker-ce/centos/
 
+	# Removing podman and buildah packages
+	if rpm -q podman >/dev/null 2>&1 || rpm -q buildah >/dev/null 2>&1; then
+		echo -n "One or more of these packages are installed: podman, buildah. The docker installation may not work with these packages installed. Would you like to remove them? (recommended: yes)"
+		if askYN ; then
+			$SUDO yum -y -q -e 0 remove podman buildah
+		else
+			echo "You chose not to remove the podman and buildah packages. The install may not succeed."
+		fi
+	fi
+
     $SUDO yum -q -e 0 makecache fast > /dev/null 2>&1
 
 	if rpm -q docker >/dev/null 2>&1 || rpm -q docker-common >/dev/null 2>&1 || rpm -q docker-selinux >/dev/null 2>&1 || rpm -q docker-engine >/dev/null 2>&1 ; then


### PR DESCRIPTION
Allows systems using RedHat Release 8 to install and removes the podman and buildah packages to avoid conflicts with Docker. To test this PR, run `install_docker.sh` and `acm_lib.sh`. 

![image](https://user-images.githubusercontent.com/105939558/216459924-66529e4f-bdb8-45e7-9c91-830a5060a9ef.png)
![image](https://user-images.githubusercontent.com/105939558/216460166-e8ae2aed-216a-44e3-8db1-a956634aff6c.png)
