### PR TITLE
Updates distribution checks to include RHEL 9

### DIFF
--- a/acmlib.sh
+++ b/acmlib.sh
@@ -291,7 +291,7 @@ warn_docker_network_in_use() {
 }
 
 check_os_is_centos () {
-    [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8' /etc/redhat-release
+    [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8\|release 9' /etc/redhat-release
 }
 
 check_os_is_ubuntu () {
@@ -303,11 +303,11 @@ require_supported_os () {
 
     #TODO: Test for minimum kernel version
     if check_os_is_centos ; then
-        echo2 "CentOS or Redhat 7 installation detected, good."
+        echo2 "CentOS or Redhat 7/8/9 installation detected, good."
     elif check_os_is_ubuntu ; then
         echo2 "Ubuntu installation detected, good."
     else
-        fail "This system does not appear to be a CentOS/ RHEL 7 or Ubuntu system"
+        fail "This system does not appear to be a CentOS/ RHEL 7/8/9 or Ubuntu system"
     fi
     return 0
 }

--- a/acmlib.sh
+++ b/acmlib.sh
@@ -295,7 +295,7 @@ check_os_is_centos () {
 }
 
 check_os_is_ubuntu () {
-    grep -iq '^DISTRIB_ID *= *Ubuntu' /etc/lsb-release
+    grep -iq '^ID *= *ubuntu' /etc/os-release
 }
 
 require_supported_os () {
@@ -391,9 +391,9 @@ ensure_common_tools_installed () {
 
     require_sudo
 
-    local ubuntu_tools="gdb wget curl iproute2 make netcat lsb-release openssh-client rsync unzip tar tzdata"
-    local centos_tools="gdb wget curl make nmap-ncat coreutils iproute redhat-lsb-core openssh-clients rsync unzip tar tzdata"
-    local required_tools="adduser awk cat chmod chown cp curl date egrep gdb getent grep ip lsb_release make mkdir mv nc passwd printf rm rsync sed ssh-keygen sleep tar tee tr unzip wc wget"
+    local ubuntu_tools="gdb wget curl iproute2 make netcat openssh-client rsync unzip tar tzdata"
+    local centos_tools="gdb wget curl make nmap-ncat coreutils iproute openssh-clients rsync unzip tar tzdata"
+    local required_tools="adduser awk cat chmod chown cp curl date egrep gdb getent grep ip make mkdir mv nc passwd printf rm rsync sed ssh-keygen sleep tar tee tr unzip wc wget"
     if [ -x /usr/bin/apt-get -a -x /usr/bin/dpkg-query ]; then
         #We have apt-get, good.
 

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -64,7 +64,7 @@ if [ "$DOCKER_CHECK" -eq 6 ]; then
 fi
 if [ "$DOCKER_CHECK" -eq 0 ]; then
 	echo "Docker appears to already be installed. Skipping."
-elif [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8' /etc/redhat-release ; then
+elif [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8\|release 9' /etc/redhat-release ; then
 	#This configuration file is used in both Redhat RHEL and Centos distributions, so we're running under RHEL/Centos 7.x
 	# https://docs.docker.com/engine/installation/linux/docker-ce/centos/
 

--- a/docker/install_docker.sh
+++ b/docker/install_docker.sh
@@ -101,7 +101,7 @@ elif [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8\|release 9' /e
 	$SUDO rpm --import ~/DOCKER-GPG-KEY
 
 	$SUDO yum -y -q -e 0 install docker-ce
-elif [ -s /etc/lsb-release ] && grep -iq '^DISTRIB_ID *= *Ubuntu' /etc/lsb-release ; then
+elif [ -s /etc/os-release ] && grep -iq '^ID *= *ubuntu' /etc/os-release ; then
 	### Install Docker on Ubuntu ###
 	# https://docs.docker.com/engine/installation/linux/docker-ce/ubuntu/#install-using-the-repository
 
@@ -118,12 +118,12 @@ elif [ -s /etc/lsb-release ] && grep -iq '^DISTRIB_ID *= *Ubuntu' /etc/lsb-relea
 	if [ "$(uname -m)" = "x86_64" ]; then
 		$SUDO add-apt-repository \
 			"deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-			$(lsb_release -cs) \
+			$(grep -E '^VERSION_CODENAME=' /etc/os-release | cut -d '=' -f 2) \
 			stable"
 	elif [ "$(uname -m)" = "aarch64" ]; then
 		$SUDO add-apt-repository \
 			"deb [arch=arm64] https://download.docker.com/linux/ubuntu \
-			$(lsb_release -cs) \
+			$(grep -E '^VERSION_CODENAME=' /etc/os-release | cut -d '=' -f 2) \
 			stable"
 	else
 		echo "Unknown 64 bit architecture, exiting."
@@ -181,7 +181,7 @@ else
 	if [ -s /etc/redhat-release ] && grep -iq 'release 7\|release 8' /etc/redhat-release ; then
 		$SUDO yum -y -q update
 		$SUDO yum -y -q -e 0 install docker-compose-plugin
-	elif [ -s /etc/lsb-release ] && grep -iq '^DISTRIB_ID *= *Ubuntu' /etc/lsb-release ; then
+	elif [ -s /etc/os-release ] && grep -iq '^ID *= *ubuntu' /etc/os-release ; then
 		$SUDO apt-get -qq update > /dev/null 2>&1
 		$SUDO apt-get -qq install docker-compose-plugin
 	fi


### PR DESCRIPTION
This change updates the bash script to include a check for RHEL 9 distributions. 
To test this PR, run `install_docker.sh` and `acm_lib.sh`. 

Previously tested on the following OS's:
- CentOS 9
- Rocky Linux 9

The patch worked well on both. 